### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/AM2320/keywords.txt
+++ b/AM2320/keywords.txt
@@ -1,4 +1,4 @@
-AM2320          KEYWORD1
+AM2320	KEYWORD1
 getTemperature	KEYWORD2
-getHumidity     KEYWORD2
-CRCCheck        KEYWORD2
+getHumidity	KEYWORD2
+CRCCheck	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords